### PR TITLE
Object.equals() in den Metrikklassen implementiert

### DIFF
--- a/src/main/java/com/swe/janalyzer/App.java
+++ b/src/main/java/com/swe/janalyzer/App.java
@@ -1,7 +1,6 @@
 package com.swe.janalyzer;
 
 
-import com.swe.janalyzer.analysis.MetricCalculator;
 import com.swe.janalyzer.analysis.MetricCalculatorImpl;
 import com.swe.janalyzer.data.metriken.Summary;
 import com.swe.janalyzer.storage.JSONConverter;
@@ -29,7 +28,7 @@ public class App
                 e.printStackTrace();
             }
             try {
-                JSONConverter.save(sum, Paths.get(args[1]));
+                JSONConverter.saveSummary(sum, Paths.get(args[1]));
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/src/main/java/com/swe/janalyzer/data/metriken/ClassMetrics.java
+++ b/src/main/java/com/swe/janalyzer/data/metriken/ClassMetrics.java
@@ -4,49 +4,61 @@ import com.swe.janalyzer.data.metriken.cc.FunctionCC;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Datenmodell für die Metriken einer Klasse.
  */
 public class ClassMetrics {
-   private int dit;
-   private List<FunctionCC> functionCCs;
+    private int dit;
+    private List<FunctionCC> functionCCs;
+    public ClassMetrics() { }
 
-   public ClassMetrics() {
-   }
-
-   public ClassMetrics(int dit) {
-      this.dit=dit;
-   }
+    public ClassMetrics(int dit) {
+        this.dit=dit;
+    }
 
     public ClassMetrics(List<FunctionCC> functionCCs) {
-      this.functionCCs = functionCCs;
+        this.functionCCs = functionCCs;
     }
 
     public int getDit() {
-      return dit;
-   }
+        return dit;
+    }
 
-   public void setDit(int dit) {
-      this.dit = dit;
-   }
+    public void setDit(int dit) {
+        this.dit = dit;
+    }
 
-   public List<FunctionCC> getFunctionCCs() {
-      return functionCCs;
-   }
+    public List<FunctionCC> getFunctionCCs() {
+        return functionCCs;
+    }
 
-   /**
-    * Setter für {@link ClassMetrics#functionCCs}
-    * @param functionCCs
-    */
-   public void setFunctionCCs(List<FunctionCC> functionCCs) {
-      this.functionCCs = functionCCs;
-   }
+    /**
+        * Setter für {@link ClassMetrics#functionCCs}
+        * @param functionCCs
+     */
+    public void setFunctionCCs(List<FunctionCC> functionCCs) {
+        this.functionCCs = functionCCs;
+    }
 
-   public int getWmcValue() {
-       return functionCCs.stream()
-               .mapToInt(FunctionCC::getCCValue)
-               .sum();
-   }
+    public int getWmcValue() {
+        return functionCCs.stream()
+            .mapToInt(FunctionCC::getCCValue)
+            .sum();
+    }
 
+    @Override
+    public boolean equals(Object o){
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClassMetrics that = (ClassMetrics) o;
+        return dit == that.dit &&
+            Objects.equals(functionCCs, that.functionCCs);
+    }
+
+    @Override
+    public int hashCode(){
+        return Objects.hash(dit, functionCCs);
+    }
 }

--- a/src/main/java/com/swe/janalyzer/data/metriken/FileMetrics.java
+++ b/src/main/java/com/swe/janalyzer/data/metriken/FileMetrics.java
@@ -1,6 +1,7 @@
 package com.swe.janalyzer.data.metriken;
 
 import java.nio.file.Path;
+import java.util.Objects;
 
 /**
  * Datenmodell für die Metriken eines Files.
@@ -34,5 +35,19 @@ public class FileMetrics {
 
     public void setSLOC(int sloc) {
         this.sloc = sloc;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FileMetrics that = (FileMetrics) o;
+        return sloc == that.sloc &&
+            Objects.equals(file, that.file);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sloc,file);
     }
 }

--- a/src/main/java/com/swe/janalyzer/data/metriken/cumulated/Cumulate.java
+++ b/src/main/java/com/swe/janalyzer/data/metriken/cumulated/Cumulate.java
@@ -1,0 +1,7 @@
+package com.swe.janalyzer.data.metriken.cumulated;
+
+import com.swe.janalyzer.data.metriken.Summary;
+
+public interface Cumulate {
+		CumulatedMetrics cumulate(Summary summary);
+}

--- a/src/main/java/com/swe/janalyzer/data/metriken/cumulated/CumulateImpl.java
+++ b/src/main/java/com/swe/janalyzer/data/metriken/cumulated/CumulateImpl.java
@@ -1,0 +1,12 @@
+package com.swe.janalyzer.data.metriken.cumulated;
+
+import com.swe.janalyzer.data.metriken.Summary;
+
+public class CumulateImpl implements Cumulate {
+
+		//TODO Kummulation implementieren!
+		@Override
+		public CumulatedMetrics cumulate(Summary summary) {
+				return new CumulatedMetrics();
+		}
+}

--- a/src/main/java/com/swe/janalyzer/data/metriken/cumulated/CumulatedMetrics.java
+++ b/src/main/java/com/swe/janalyzer/data/metriken/cumulated/CumulatedMetrics.java
@@ -1,0 +1,49 @@
+package com.swe.janalyzer.data.metriken.cumulated;
+
+public class CumulatedMetrics {
+		private int locCummulated;
+		private int ditCummulated;
+		private int ccCummulated;
+		private int wmcCummulated;
+
+		public CumulatedMetrics() { }
+
+		public CumulatedMetrics(int locCummulated, int ditCummulated, int ccCummulated, int wmcCummulated) {
+				this.locCummulated = locCummulated;
+				this.ditCummulated = ditCummulated;
+				this.ccCummulated = ccCummulated;
+				this.wmcCummulated = wmcCummulated;
+		}
+
+		public int getLocCummulated() {
+				return locCummulated;
+		}
+
+		public void setLocCummulated(int locCummulated) {
+				this.locCummulated = locCummulated;
+		}
+
+		public int getDitCummulated() {
+				return ditCummulated;
+		}
+
+		public void setDitCummulated(int ditCummulated) {
+				this.ditCummulated = ditCummulated;
+		}
+
+		public int getCcCummulated() {
+				return ccCummulated;
+		}
+
+		public void setCcCummulated(int ccCummulated) {
+				this.ccCummulated = ccCummulated;
+		}
+
+		public int getWmcCummulated() {
+				return wmcCummulated;
+		}
+
+		public void setWmcCummulated(int wmcCummulated) {
+				this.wmcCummulated = wmcCummulated;
+		}
+}

--- a/src/main/java/com/swe/janalyzer/storage/JSONConverter.java
+++ b/src/main/java/com/swe/janalyzer/storage/JSONConverter.java
@@ -8,6 +8,7 @@ import com.swe.janalyzer.data.metriken.FileMetrics;
 import com.swe.janalyzer.data.metriken.Summary;
 import com.swe.janalyzer.util.ClassSpecifier;
 import com.swe.janalyzer.util.Constants;
+import com.swe.janalyzer.util.Options;
 import com.swe.janalyzer.util.type.adapter.ClassSpecifierTypeAdapter;
 import com.swe.janalyzer.util.type.adapter.PathTypeAdapter;
 
@@ -27,13 +28,26 @@ import java.util.stream.Stream;
  */
 public class JSONConverter {
 
+		public static void saveOptions(Options options) throws IOException, NullPointerException {
+				if (options == null) throw new NullPointerException();
+				Gson gson = new GsonBuilder()
+						.setPrettyPrinting()
+						.registerTypeHierarchyAdapter(Path.class, new PathTypeAdapter())
+						.create();
+				String json = gson.toJson(options);
+
+				Path filePath = Constants.OPTION_PATH;
+				Files.createDirectories(filePath.getParent());
+				Files.write(filePath, json.getBytes());
+		}
+
 		/**
 		 * Speichert ein Objekt der Klasse Summary als .json ab.
 		 * @param summary - Das zu speichernde Objekt.
 		 * @param filePath - Der Pfad zur zu speichernden Datei.
 		 * @throws IOException Wird ausgelöst, wenn das Programm nicht in die Datei schreiben kann.
 		 */
-		public static void save(Summary summary, Path filePath) throws IOException, NullPointerException {
+		public static void saveSummary(Summary summary, Path filePath) throws IOException, NullPointerException {
 				Gson gson = new GsonBuilder()
 						.setPrettyPrinting()
 						.registerTypeHierarchyAdapter(Path.class, new PathTypeAdapter())
@@ -53,7 +67,7 @@ public class JSONConverter {
 		 * @return Gibt die ausgelesene Datei als Summary zurück
 		 * @throws IOException Wird ausgelöst, wenn das Programm die Datei nicht lesen konnte.
 		 */
-		public static Summary load (Path filePath) throws IOException, NullPointerException {
+		public static Summary loadSummary(Path filePath) throws IOException, NullPointerException {
 				Gson gson = new GsonBuilder()
 						.registerTypeHierarchyAdapter(Path.class, new PathTypeAdapter())
 						.registerTypeHierarchyAdapter(ClassSpecifier.class, new ClassSpecifierTypeAdapter())
@@ -72,5 +86,14 @@ public class JSONConverter {
 				res.setClassMetrics(map);
 				res.setFileMetrics(list);
 				return res;
+		}
+
+		public static Options loadOptions() throws IOException {
+				Gson gson = new GsonBuilder()
+						.registerTypeHierarchyAdapter(Path.class, new PathTypeAdapter())
+						.create();
+
+				String data = (Files.lines(Constants.OPTION_PATH)).collect(Collectors.joining("\n"));
+				return gson.fromJson(data, Options.class);
 		}
 }

--- a/src/main/java/com/swe/janalyzer/util/Constants.java
+++ b/src/main/java/com/swe/janalyzer/util/Constants.java
@@ -9,4 +9,6 @@ import java.nio.file.Paths;
  */
 public class Constants {
 		public static final String SEPERATOR = "@=@";
+		public static final String DEFAULT_PATH = "default";
+		public static final String CUSTOM_PATH = "custom";
 }

--- a/src/main/java/com/swe/janalyzer/util/Constants.java
+++ b/src/main/java/com/swe/janalyzer/util/Constants.java
@@ -9,6 +9,8 @@ import java.nio.file.Paths;
  */
 public class Constants {
 		public static final String SEPERATOR = "@=@";
+
 		public static final String DEFAULT_PATH = "default";
 		public static final String CUSTOM_PATH = "custom";
+		public static final Path OPTION_PATH = Paths.get("./output/options.json");
 }

--- a/src/main/java/com/swe/janalyzer/util/Options.java
+++ b/src/main/java/com/swe/janalyzer/util/Options.java
@@ -1,0 +1,74 @@
+package com.swe.janalyzer.util;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+public class Options {
+		private int loc;
+		private int dit;
+		private int cc;
+		private int wmc;
+
+		private String customPathName;
+		private Path customPath;
+
+		public int getLoc() {
+				return loc;
+		}
+
+		public void setLoc(int loc) {
+				this.loc = loc;
+		}
+
+		public int getDit() {
+				return dit;
+		}
+
+		public void setDit(int dit) {
+				this.dit = dit;
+		}
+
+		public int getCc() {
+				return cc;
+		}
+
+		public void setCc(int cc) {
+				this.cc = cc;
+		}
+
+		public int getWmc() {
+				return wmc;
+		}
+
+		public void setWmc(int wmc) {
+				this.wmc = wmc;
+		}
+
+		public String getCustomPathName() {
+				return customPathName;
+		}
+
+		public Path getCustomPath() {
+				return customPath;
+		}
+
+		public void setCustomPath(String customPathName, Path customPath) {
+				this.customPathName = customPathName;
+				this.customPath = customPath;
+		}
+
+		@Override
+		public boolean equals(Object o){
+				if (this == o) return true;
+				if (o == null || getClass() != o.getClass()) return false;
+				Options that = (Options) o;
+				return loc == that.loc && dit == that.dit && cc == that.cc && wmc == that.wmc &&
+						Objects.equals(customPathName, that.customPathName) &&
+						Objects.equals(customPath, that.customPath);
+		}
+
+		@Override
+		public int hashCode() {
+				return Objects.hash(loc,dit,cc,wmc,customPathName,customPath);
+		}
+}

--- a/src/main/java/com/swe/janalyzer/util/PathManager.java
+++ b/src/main/java/com/swe/janalyzer/util/PathManager.java
@@ -1,0 +1,47 @@
+package com.swe.janalyzer.util;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class PathManager {
+		public static PathManager instance;
+		private Path defaultPath, customPath;
+		private String choice;
+
+		public PathManager(){
+				this.defaultPath = Paths.get(System.getProperty("user.home") + "/janalyzer");
+				this.choice = Constants.DEFAULT_PATH;
+		}
+
+		public static PathManager getInstance() {
+				if(instance == null) instance = new PathManager();
+				return instance;
+		}
+
+		public void choosePath(String choice) {
+				switch (choice){
+						case Constants.DEFAULT_PATH:
+								this.choice = choice;
+								break;
+						case Constants.CUSTOM_PATH:
+								this.choice = choice;
+								break;
+						default:
+								this.choice = Constants.DEFAULT_PATH;
+								break;
+				}
+		}
+
+		public void setCustomPath(Path custom){
+				this.customPath = custom;
+		}
+
+		public Path getChoosenPath() {
+				if(this.choice.equals(Constants.CUSTOM_PATH) && this.customPath != null){
+						return this.customPath;
+				}
+				return this.defaultPath;
+		}
+
+
+}

--- a/src/test/java/com/swe/janalyzer/JSONConverterTest.java
+++ b/src/test/java/com/swe/janalyzer/JSONConverterTest.java
@@ -6,9 +6,8 @@ import com.swe.janalyzer.data.metriken.Summary;
 import com.swe.janalyzer.data.metriken.cc.FunctionCC;
 import com.swe.janalyzer.storage.JSONConverter;
 import com.swe.janalyzer.util.ClassSpecifier;
-import org.junit.Assert;
+import com.swe.janalyzer.util.Options;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -23,6 +22,7 @@ import static org.junit.Assert.*;
 
 public class JSONConverterTest {
 		private Summary summary;
+		private Options options;
 		private Path correctPath;
 		private Path incorrectPath;
 
@@ -68,12 +68,19 @@ public class JSONConverterTest {
 
 				correctPath = Paths.get("./result.json");
 				incorrectPath = Paths.get("./asd");
+
+				options = new Options();
+				options.setCc(2);
+				options.setDit(4);
+				options.setCustomPath("hallo", incorrectPath);
+				options.setLoc(200);
+				options.setWmc(7);
 		}
 
 		@Test
-		public void testSave(){
+		public void testSaveSummary(){
 				try {
-						JSONConverter.save(summary, correctPath);
+						JSONConverter.saveSummary(summary, correctPath);
 				} catch (IOException ioe) {
 						fail("IOException wasn't expected.");
 				} catch (NullPointerException ne) {
@@ -81,7 +88,7 @@ public class JSONConverterTest {
 				}
 
 				try {
-						JSONConverter.save(summary, null);
+						JSONConverter.saveSummary(summary, null);
 						fail("NullPointerException was expected.");
 				} catch (IOException ioe) {
 						fail("IOException wasn't expected.");
@@ -89,7 +96,7 @@ public class JSONConverterTest {
 				}
 
 				try {
-						JSONConverter.save(null, correctPath);
+						JSONConverter.saveSummary(null, correctPath);
 						fail("NullPointerException was expected.");
 				} catch (IOException ioe) {
 						fail("IOException wasn't expected.");
@@ -97,7 +104,7 @@ public class JSONConverterTest {
 				}
 
 				try {
-						JSONConverter.save(null, null);
+						JSONConverter.saveSummary(null, null);
 						fail("NullPointerException was expected.");
 				} catch (IOException ioe) {
 						fail("IOException wasn't expected.");
@@ -106,18 +113,18 @@ public class JSONConverterTest {
 		}
 
 		@Test
-		public void testLoad() throws IOException {
+		public void testLoadSummary() throws IOException {
 				try {
-						JSONConverter.save(summary, correctPath);
+						JSONConverter.saveSummary(summary, correctPath);
 				} catch (IOException ioe) {
 						fail("IOException wasn't expected.");
 				} catch (NullPointerException ne) {
 						fail("NullPointerException wasn't expected.");
 				}
-				Summary loaded = JSONConverter.load(correctPath);
+				Summary loaded = JSONConverter.loadSummary(correctPath);
 
 				try {
-						Summary sum1 = JSONConverter.load(correctPath);
+						Summary sum1 = JSONConverter.loadSummary(correctPath);
 						assertEquals(summary, sum1);
 						
 						Summary sumWrong = new Summary();
@@ -130,11 +137,46 @@ public class JSONConverterTest {
 				}
 
 				try {
-						JSONConverter.load(null);
+						JSONConverter.loadSummary(null);
 						fail("NullPointerException was expected.");
 				} catch (IOException ioe) {
 						fail("IOException wasn't expected.");
 				} catch (NullPointerException ne) {
+				}
+		}
+
+		@Test
+		public void testSaveOptions() {
+				try {
+						JSONConverter.saveOptions(options);
+				} catch (IOException io) {
+						fail("IOException wasn't expected.");
+				} catch (NullPointerException ne){
+						fail("NullPointerException wasn't expected.");
+				}
+
+				try {
+						JSONConverter.saveOptions(null);
+						fail("NullPointerException was expected.");
+				} catch (IOException io) {
+						fail("IOException wasn't expected.");
+				} catch (NullPointerException ne){
+				}
+		}
+
+		@Test
+		public void testLoadOptions() {
+				try {
+						JSONConverter.saveOptions(options);
+				} catch (IOException e) {
+						fail("IOException wasn't expected.");
+				}
+
+				try {
+						Options option = JSONConverter.loadOptions();
+						option.equals(options);
+				} catch (IOException e) {
+						fail("IOException wasn't expected.");
 				}
 		}
 }

--- a/src/test/java/com/swe/janalyzer/JSONConverterTest.java
+++ b/src/test/java/com/swe/janalyzer/JSONConverterTest.java
@@ -118,7 +118,11 @@ public class JSONConverterTest {
 
 				try {
 						Summary sum1 = JSONConverter.load(correctPath);
-						//assertEquals(summary, sum1);
+						assertEquals(summary, sum1);
+						
+						Summary sumWrong = new Summary();
+						sumWrong.setClassMetrics(summary.getClassMetrics());
+						assertNotEquals(sumWrong, sum1);
 				} catch (IOException ioe) {
 						fail("IOException wasn't expected.");
 				} catch (NullPointerException ne) {

--- a/src/test/java/com/swe/janalyzer/PathManagerTest.java
+++ b/src/test/java/com/swe/janalyzer/PathManagerTest.java
@@ -1,0 +1,14 @@
+package com.swe.janalyzer;
+
+import com.swe.janalyzer.util.Constants;
+import com.swe.janalyzer.util.PathManager;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+
+public class PathManagerTest {
+
+		@Test
+		public void testManager() {
+		}
+}

--- a/src/test/java/com/swe/janalyzer/analysis/TestdateienTests.java
+++ b/src/test/java/com/swe/janalyzer/analysis/TestdateienTests.java
@@ -25,8 +25,8 @@ public class TestdateienTests {
         Path expectedPath = Paths.get("./src/test/java/com/swe/janalyzer/analysis/project_results/graph_expected");
         Files.createDirectories(calcPath.getParent());
         Files.createDirectories(expectedPath.getParent());
-        JSONConverter.save(calculated, calcPath);
-        JSONConverter.save(expected, expectedPath); //Stackoverflow error
+        JSONConverter.saveSummary(calculated, calcPath);
+        JSONConverter.saveSummary(expected, expectedPath); //Stackoverflow error
         assertTrue(Util.equals(calculated, expected));
     }
 


### PR DESCRIPTION
In ClassMetrics kam es zu Zeilenverschiebungen auf Grund von vorherigen, falschen Formatierungen